### PR TITLE
Improvement/support scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: scala
 scala:
   - 2.10.6
   - 2.11.7
+  - 2.12.2
 jdk:
   - oraclejdk8
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: scala
 scala:
   - 2.10.6
-  - 2.11.7
+  - 2.11.11
   - 2.12.2
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To publish your library to BinTray follow these steps:
 * From the command line login to BinTray: `activator bintray::changeCredentials`
 * Change the version via Git:  `git tag vX.Y.Z`
 * Publish your library: `activator +bintray::publish`
-                Note: The `+` publishes the cross-versioned (e.g. Scala 2.10 & 2.11) builds.
+                Note: The `+` publishes the cross-versioned (e.g. Scala 2.10 & 2.11 & 2.12) builds.
                 
                 
 To enable others to use your library you can either have them add a new resolver / repository to their build or you can [add your library to Maven Central via jCenter](http://blog.bintray.com/2014/02/11/bintray-as-pain-free-gateway-to-maven-central/).

--- a/build.sbt
+++ b/build.sbt
@@ -9,15 +9,15 @@ enablePlugins(GitVersioning)
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.2"
 
-crossScalaVersions := Seq("2.10.6", "2.11.7")
+crossScalaVersions := Seq("2.10.6", "2.11.7", "2.12.2")
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "org.mockito" % "mockito-all" % "1.10.19" % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
 scalaVersion := "2.12.2"
 
-crossScalaVersions := Seq("2.10.6", "2.11.7", "2.12.2")
+crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2")
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,15 +23,15 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
 
 // SBT-Scoverage version must be compatible with SBT-coveralls version below
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 
 
 addSbtPlugin("com.updateimpact" % "updateimpact-sbt-plugin" % "2.1.1")
 
 
-addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "1.2.1")
+addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "1.3.5")
 
 
 // Provides site generation functionality

--- a/src/main/scala/com/taxis99/aws/S3Client.scala
+++ b/src/main/scala/com/taxis99/aws/S3Client.scala
@@ -2,7 +2,7 @@ package com.taxis99.aws
 
 import java.io.{ ByteArrayInputStream, File => JFile }
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 import org.joda.time.DateTime
 
@@ -41,7 +41,6 @@ class S3Client(bucketName: String)(implicit provider: AWSCredentialsProvider) {
   }
 
   def listFiles(prefix: String) = {
-    client.listObjects(bucketName, prefix).getObjectSummaries.sortBy(_.getLastModified).reverse
+    client.listObjects(bucketName, prefix).getObjectSummaries.asScala.sortBy(_.getLastModified).reverse
   }
-
 }

--- a/src/main/scala/com/taxis99/aws/SNSSQSSubscriber.scala
+++ b/src/main/scala/com/taxis99/aws/SNSSQSSubscriber.scala
@@ -1,6 +1,6 @@
 package com.taxis99.aws
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.auth.policy.{ Policy, Principal, Resource, Statement }
@@ -71,7 +71,6 @@ abstract class SNSSQSSubscriber(sqsEndpoint: String, snsEndpoint: String)(implic
 
     sqsClient.setQueueAttributes(new SetQueueAttributesRequest()
       .withQueueUrl(queueUrl)
-      .withAttributes(Map(QueueAttributeName.Policy.toString -> policy.toJson)))
+      .withAttributes(Map(QueueAttributeName.Policy.toString -> policy.toJson).asJava))
   }
-
 }

--- a/src/test/scala/com/taxis99/aws/S3ClientSpec.scala
+++ b/src/test/scala/com/taxis99/aws/S3ClientSpec.scala
@@ -3,7 +3,7 @@ package com.taxis99.aws
 import java.io.{ ByteArrayInputStream, File => JFile }
 import java.net.URL
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 import org.joda.time.DateTime
 import org.mockito.Matchers.{ any, anyString, same }
@@ -26,7 +26,7 @@ class S3ClientSpec extends WordSpec with MustMatchers with BeforeAndAfter {
 
       val objectListing = mock(classOf[ObjectListing])
       when(objectListing.getObjectSummaries())
-        .thenReturn(List[S3ObjectSummary]())
+        .thenReturn(List[S3ObjectSummary]().asJava)
       when(s3.listObjects(anyString(), anyString()))
         .thenReturn(objectListing)
       when(s3.generatePresignedUrl(any[GeneratePresignedUrlRequest]))

--- a/src/test/scala/com/taxis99/aws/SNSSQSSubscriberSpec.scala
+++ b/src/test/scala/com/taxis99/aws/SNSSQSSubscriberSpec.scala
@@ -1,6 +1,6 @@
 package com.taxis99.aws
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{ mock, times, verify, when }
@@ -8,7 +8,6 @@ import org.scalatest.{ BeforeAndAfter, MustMatchers, WordSpec }
 
 import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sns.model._
-import com.amazonaws.services.sqs.AmazonSQSClient
 import com.amazonaws.services.sqs.model._
 import com.amazonaws.services.sqs.AmazonSQS
 import com.taxis99.aws.credentials.BasicAWSCredentialsProvider
@@ -35,7 +34,7 @@ class SNSSQSSubscriberSpec extends WordSpec with MustMatchers with BeforeAndAfte
       when(sqs.createQueue(new CreateQueueRequest("@queue")))
         .thenReturn(new CreateQueueResult().withQueueUrl("@queueUrl"))
       when(sqs.getQueueAttributes(any()))
-        .thenReturn(new GetQueueAttributesResult().withAttributes(Map(QueueAttributeName.QueueArn.toString -> "@queueArn")))
+        .thenReturn(new GetQueueAttributesResult().withAttributes(Map(QueueAttributeName.QueueArn.toString -> "@queueArn").asJava))
       sqs
     }
   }


### PR DESCRIPTION
Changes to add support to Scala 2.12 version

- Updated scalaVersion in sbt and travis files
- Updated scalatest library
- Updated plugins (sbt-scoverage, sbt-coveralls and sbt-codacy-coverage)
- Added suport to latest scala 2.11.x version (2.11.11)
- Removed deprecated JavaConversions methods and replaced to JavaConverters
http://www.scala-lang.org/api/2.12.0/scala/collection/JavaConversions$.html
https://issues.scala-lang.org/browse/SI-9684
